### PR TITLE
remove get_genomic coordinates from spliceai api

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,6 @@
             "env": {
                 "GRCH37_FASTA": "${workspaceFolder}/tests/data/chr21_grch37.fa.gz",
                 "GRCH38_FASTA": "${workspaceFolder}/tests/data/chr21_grch38.fa.gz",
-                "ENSEMBL_TIMEOUT": "120",
                 "ALLOW_ALL_ORIGIN": "true",
                 "DEBUG": "true"
             }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Note:
 ```
 GRCH37_FASTA=/hg_ref/Homo_sapiens_assembly19.fasta.gz
 GRCH38_FASTA=/hg_ref/Homo_sapiens_assembly38.fasta.gz
-ENSEMBL_TIMEOUT=120 # Timeout in seconds for Ensembl REST API services (seconds)
 ```
 
 ## Running

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -10,7 +10,6 @@ services:
     environment:
       GRCH37_FASTA: "/hg_ref/Homo_sapiens_assembly38.fasta"
       GRCH38_FASTA: "/hg_ref/Homo_sapiens_assembly38.fasta"
-      ENSEMBL_TIMEOUT: "120"
     ports:
       - "5001:5001"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     environment:
       GRCH37_FASTA: "/hg_ref/Homo_sapiens_assembly19.fasta"
       GRCH38_FASTA: "/hg_ref/Homo_sapiens_assembly38.fasta"
-      ENSEMBL_TIMEOUT: "120"
     ports:
       - "5001:5001"
     restart: unless-stopped

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,4 +9,3 @@ log_cli_format = %(asctime)s %(name)-12s %(funcName)-12s %(levelname)-8s %(messa
 env =
     GRCH38_FASTA=hg_ref/chr21_grch38.fa.gz
     GRCH37_FASTA=hg_ref/chr21_grch37.fa.gz
-    ENSEMBL_TIMEOUT=120

--- a/spliceai_api/__init__.py
+++ b/spliceai_api/__init__.py
@@ -1,6 +1,0 @@
-import os
-
-# Check for ENSEMBL_TIMEOUT environment variable
-ENSEMBL_TIMEOUT = os.getenv("ENSEMBL_TIMEOUT")
-if ENSEMBL_TIMEOUT is None:
-    raise EnvironmentError("Environment variable 'ENSEMBL_TIMEOUT' is not declared. Please set this variable before running the application.")

--- a/spliceai_api/app.py
+++ b/spliceai_api/app.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 
 from spliceai.utils import Annotator
 from spliceai_api.exceptions import SpliceAIAPIException
-from spliceai_api.utils import score_custom_sequence, ensembl_get_genomic_coord, get_delta_scores, Record, validate_fasta, load_annotations
+from spliceai_api.utils import score_custom_sequence, get_delta_scores, Record, validate_fasta, load_annotations
 
 # Determine the logging level based on an environment variable
 logging_level = logging.DEBUG if os.getenv("DEBUG") == "true" else logging.INFO
@@ -168,34 +168,6 @@ async def api_score_custom_seq(sequence: str):
              'details':f"Entered sequence must contain ATCG and not be blank"}))
     return score_custom_sequence(sequence=sequence)
 
-
-@app.get("/get_genomic_coord/{assembly}/{variant}")
-async def api_get_genomic_coord(variant: str, assembly: str = 'grch38') -> dict:
-    """Obtain genomic coordinates for a given variant
-
-    Args:
-        variant (str): Variant. This can be HGVSc, HGVSg
-        assembly (str): 'grch38' or 'grch37'
-
-    Returns:
-        dict: Genomic coordinates consisting of 'chr', 'pos', 'ref' and 'alt'
-    """
-    if assembly not in annotations.keys():
-        raise DefaultException(status_code=400, detail=jsonable_encoder(
-            {'summary':'Invalid assembly',
-             'details':f"{assembly} is not a valid assembly"}))
-
-    try:
-        gcoord = ensembl_get_genomic_coord(variant=variant, assembly=annotations[assembly]['assembly'])
-        return(gcoord)
-    except HTTPError as e:
-        raise HTTPException(status_code=e.response.status_code, detail=jsonable_encoder(
-            {'summary':'Encountered error while translating variant',
-             'details': e.response.json()['error']}))
-    except Exception as e:
-        raise DefaultException(status_code=500, detail=jsonable_encoder(
-            {'summary':'Encountered error while translating variant',
-             'details':e.__doc__}))
         
 @app.post("/get_delta_scores/")
 async def api_get_delta_scores(variant: SingleVariant) -> list[DeltaScore]:

--- a/spliceai_api/app.py
+++ b/spliceai_api/app.py
@@ -138,16 +138,6 @@ def get_ready():
     """
     return {"status": "ready"}
 
-@app.get("/get_annotations")
-async def api_get_annotations():
-    """
-    API endpoint to get available annotations.
-
-    Returns:
-        dict: A dictionary of annotations available in the API.
-    """
-    return annotations
-
 @app.get("/score_custom_seq/{sequence}")
 async def api_score_custom_seq(sequence: str):
     """

--- a/spliceai_api/utils.py
+++ b/spliceai_api/utils.py
@@ -4,7 +4,6 @@ import logging, os
 from importlib.resources import files
 
 from spliceai_api.exceptions import SpliceAIAPIException
-from spliceai_api import ENSEMBL_TIMEOUT
 
 import requests
 from keras.models import load_model
@@ -50,27 +49,6 @@ def score_custom_sequence(sequence: str) -> dict:
         'acceptor_prob': y[0, :, 1].tolist(),
         'donor_prob': y[0, :, 2].tolist()
     }
-
-def ensembl_get_genomic_coord(variant: str, assembly: str = 'grch38') -> dict:
-    logger.debug(f"Obtaining genomic position for variant: {variant}, assembly: {assembly}")
-    server = 'https://grch37.rest.ensembl.org' if assembly=='grch37' else 'https://rest.ensembl.org'
-    ext = f"/variant_recoder/human/{variant}?fields=None&vcf_string=1"
-    logger.debug(f"Ensembl URL: {server}{ext}")
-
-    resp = requests.get(server+ext, headers={ "Content-Type" : "application/json"}, timeout=float(ENSEMBL_TIMEOUT))
-    if not resp.ok:
-        resp.raise_for_status()
-
-    resp_json = resp.json()
-
-    chrom, pos, ref, alt = resp_json[0][list(resp_json[0].keys())[0]]['vcf_string'][0].split('-')
-
-    return({
-        'chr': chrom,
-        'pos': pos,
-        'ref': ref,
-        'alt': alt
-    })
 
 def get_delta_scores(record, ann, dist_var, mask):
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,12 +11,6 @@ data = [
     ('invalid_sequence', 'XYAX', 400)
 ]
 
-variants = [
-    ('valid_hgvsc', 'NM_005502:c.66+5G>C', 'grch38', 200, {'chr': '9', 'pos': '104903609', 'ref': 'C', 'alt': 'G'}),
-    ('invalid_hgvsc', 'NM_005502:c.+5G>C', 'grch38', 400, None),
-    ('invalid_assembly', 'NM_005502.3:c.+5G>C', 'grch99', 400, None)
-]
-
 variants_for_spliceai = [
     ('valid', {'chr': '21', 'pos': 26840275, 'ref': 'C', 'alt': 'A'}, 'grch38', 50, 0, 200),
     ('invalid_chromosome', {'chr': '1', 'pos': 26840275, 'ref': 'G', 'alt': 'A'}, 'grch38', 50, 0, 400),
@@ -32,13 +26,6 @@ def idfn(test_data):
 def test_score_custom_seq(id, input, response_code):
     response = client.get(f"/score_custom_seq/{input}")
     assert response.status_code == response_code
-
-@pytest.mark.parametrize("id,input,assembly,response_code,genomic", variants, ids=idfn(variants))
-def test_get_genomic_coord(id, input, assembly, response_code, genomic):
-    response = client.get(f"/get_genomic_coord/{assembly}/{input}")
-    assert response.status_code == response_code
-    if response.status_code == 200:
-        assert response.json() == genomic
 
 @pytest.mark.parametrize("id,genomic,annotation,distance,mask,response_code", variants_for_spliceai, ids=idfn(variants_for_spliceai))
 def test_get_delta_scores(id, genomic, annotation, distance, mask, response_code):


### PR DESCRIPTION
This endpoint is no longer need by the SpliceSightV2 web ui. It is however still in use by the existing SpliceSight implementation and cannot be removed yet.